### PR TITLE
Add a default monospace font

### DIFF
--- a/page.css
+++ b/page.css
@@ -1,6 +1,6 @@
 body {
 	margin: 0px 0px 0px 0px;
-	font-family: 'Lucida Console';
+	font-family: 'Lucida Console', monospace;
 }
 
 #left {


### PR DESCRIPTION
Some people (like me) don't have Lucida Console installed on their system (I'm using Linux), for them, it just shows up as the browser's default font, which usually isn't monospace. This fixes that issue by using the browser's default monospace font as a default.
